### PR TITLE
Added roles to main server, updated meeting stuff, refactored routes

### DIFF
--- a/backend/.flake8
+++ b/backend/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 exclude = .git, auth/utils/make_config.py, tests/*
 max_line_length = 88
-ignore = E402, W503
+ignore = E402, W503, E501

--- a/backend/auth/dependencies.py
+++ b/backend/auth/dependencies.py
@@ -21,7 +21,7 @@ print("Using CONFIG_PATH:", CONFIG_PATH)
 config = toml.load(str(CONFIG_PATH))
 SECRET_KEY = config["secret"]
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MIN = 180
+ACCESS_TOKEN_EXPIRE_MIN = 240
 
 
 class Token(BaseModel):

--- a/backend/main/db/docs/meeting_doc.py
+++ b/backend/main/db/docs/meeting_doc.py
@@ -3,9 +3,9 @@ from mongoengine import (
     Document,
     StringField,
     ListField,
-    DateField,
     DateTimeField,
     QuerySet,
+    UUIDField,
 )
 
 
@@ -21,13 +21,14 @@ def document(model: MeetingModel):
 class MeetingDocument(Document):
     _model = MeetingModel
 
-    meeting_date = DateField(required=True)
-    meeting_time = DateTimeField(required=True)
+    uuid = UUIDField(required=True)
+    date_and_time = DateTimeField(required=True)
+    duration = DateTimeField(required=True)
     zoom_link = StringField(required=True)
     topic = StringField(required=True)
     session_level = StringField(required=True)
     miro_link = StringField(required=True)
-    meeting_password = StringField(required=True)
+    password = StringField(required=True)
     students = ListField(required=False)
 
     meta = {
@@ -36,13 +37,36 @@ class MeetingDocument(Document):
         "indexes": ["session_level"],
     }
 
-    def dict(self):
+    def student_dict(self):
         return {
-            "meeting_date": self.meeting_date,
-            "meeting_time": self.meeting_time,
+            "uuid": self.uuid,
+            "date_and_time": self.date_and_time,
+            "duration": self.duration,
             "zoom_link": self.zoom_link,
             "topic": self.topic,
             "session_level": self.session_level,
-            "meeting_password": self.meeting_password,
+        }
+
+    def admin_dict(self):
+        return {
+            "uuid": self.uuid,
+            "date_and_time": self.date_and_time,
+            "duration": self.duration,
+            "zoom_link": self.zoom_link,
+            "topic": self.topic,
+            "session_level": self.session_level,
+            "password": self.password,
+            "students": self.students,
+        }
+
+    def dict(self):
+        return {
+            "uuid": self.uuid,
+            "date_and_time": self.date_and_time,
+            "duration": self.duration,
+            "zoom_link": self.zoom_link,
+            "topic": self.topic,
+            "session_level": self.session_level,
+            "password": self.password,
             "students": self.students,
         }

--- a/backend/main/db/docs/student_profile_doc.py
+++ b/backend/main/db/docs/student_profile_doc.py
@@ -1,10 +1,6 @@
-from typing import List
-
 from mongoengine import Document, ListField, EmailField, QuerySet, UUIDField
 
 from backend.main.db.models.student_profile_model import (
-    Guardian,
-    Student,
     StudentProfileModel,
 )
 
@@ -13,24 +9,11 @@ class StudentProfileQuerySet(QuerySet):
     pass
 
 
-def document(
-    model: StudentProfileModel,
-    guardians: List[Guardian],
-    students: List[Student],
-):
-    guardian_list = []
-    for guardian in guardians:
-        guardian_list.append(guardian.dict())
-    student_list = []
-    for student in students:
-        student_list.append(student.dict())
-    doc = StudentProfileDocument(
-        **model.dict(), guardians=guardian_list, students=student_list
-    )
+def document(model: StudentProfileModel):
+    doc = StudentProfileDocument(**model.dict())
     return doc
 
 
-# SUGGESTION: change student_list to students?
 class StudentProfileDocument(Document):
     _model = StudentProfileModel
 

--- a/backend/main/db/mixins.py
+++ b/backend/main/db/mixins.py
@@ -1,6 +1,13 @@
+from enum import Enum
 from typing import Any, Optional
 
 from pydantic import BaseModel, Field, validator
+
+
+class SessionLevel(str, Enum):
+    junior_a = "junior_a"
+    junior_b = "junior_b"
+    senior = "senior"
 
 
 class IdMixin(BaseModel):

--- a/backend/main/db/models/meeting_model.py
+++ b/backend/main/db/models/meeting_model.py
@@ -1,10 +1,17 @@
 from typing import Optional, List
 from datetime import datetime, date
+from uuid import uuid4
 
-from pydantic import Field, BaseModel, EmailStr
+from pydantic import Field, BaseModel, EmailStr, UUID4
 
-from backend.main.db.mixins import IdMixin
+from backend.main.db.mixins import SessionLevel
 from backend.main.db.models.student_profile_model import Guardian
+
+
+class StudentMeetingRegistration(BaseModel):
+    meeting_id: UUID4 = Field()
+    first_name: str = Field()
+    last_name: str = Field()
 
 
 class StudentMeetingInfo(BaseModel):
@@ -12,14 +19,24 @@ class StudentMeetingInfo(BaseModel):
     last_name: str = Field()
     email: EmailStr = Field()
     guardians: List[Guardian] = Field()
+    account_uuid: UUID4 = Field()
 
 
-class MeetingModel(IdMixin):
-    meeting_date: date = Field()
-    meeting_time: datetime = Field()
+class CreateMeetingModel(BaseModel):
+    date_and_time: datetime = Field()
+    duration: datetime = Field()
     zoom_link: str = Field()
-    session_level: str = Field()
-    topic: str = Field()
-    miro_link: str = Field()
-    meeting_password: Optional[str] = Field()
-    students: Optional[list] = Field()
+    session_level: SessionLevel = Field()
+    topic: Optional[str] = Field()
+    miro_link: Optional[str] = Field()
+
+
+class MeetingModel(CreateMeetingModel):
+    uuid: UUID4 = Field(default_factory=uuid4)
+    students: List[StudentMeetingInfo] = Field()
+    password: str = Field()
+
+
+class MeetingSearchModel(BaseModel):
+    session_levels: Optional[List[SessionLevel]]
+    dates: Optional[List[date]]

--- a/backend/main/db/models/student_profile_model.py
+++ b/backend/main/db/models/student_profile_model.py
@@ -1,8 +1,8 @@
-from pydantic import BaseModel
+from typing import List
 
-from pydantic import Field, EmailStr, UUID4
+from pydantic import BaseModel, Field, EmailStr, UUID4
 
-from backend.main.db.mixins import IdMixin
+from backend.main.db.mixins import SessionLevel
 
 
 class Guardian(BaseModel):
@@ -17,9 +17,17 @@ class Student(BaseModel):
     last_name: str = Field()
     grade: int = Field()
     age: int = Field()
-    section: list = Field()
+    section: List[SessionLevel] = Field()
 
 
-class StudentProfileModel(IdMixin):
-    uuid: UUID4 = Field()
+# this is the model for the API since
+# we will use the uuid from the token
+# for the StudentProfileModel
+class StudentProfileCreateModel(BaseModel):
     email: EmailStr = Field()
+    students: List[Student]
+    guardians: List[Guardian]
+
+
+class StudentProfileModel(StudentProfileCreateModel):
+    uuid: UUID4 = Field()

--- a/backend/main/src/app.py
+++ b/backend/main/src/app.py
@@ -16,6 +16,7 @@ import uvicorn
 
 # main db imports
 from backend.main.src.routers import user_router, meeting_router
+from backend.main.src.routers import student, admin
 from backend.connect_to_mongodb import connect_to_mongodb, connect_to_auth_db
 
 # auth db imports
@@ -35,6 +36,9 @@ app = FastAPI()
 
 app.include_router(user_router.router, prefix="/user_router", tags=["Users"])
 app.include_router(meeting_router.router, prefix="/meetings_router", tags=["Meetings"])
+
+app.include_router(student.router, prefix="/student", tags=["Students"])
+app.include_router(admin.router, prefix="/admin", tags=["Admin"])
 
 # TODO: make a list of origins, for now the server allows requests from everywhere
 # possible a origin_regex could be used instead which matches anything that starts with
@@ -75,7 +79,8 @@ async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends(
         )
     access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MIN)
     access_token = create_access_token(
-        data={"sub": str(user.id)}, expires_delta=access_token_expires
+        data={"sub": str(user.id), "role": user.role},
+        expires_delta=access_token_expires,
     )
     return {"access_token": access_token, "token_type": "bearer"}
 

--- a/backend/main/src/routers/admin.py
+++ b/backend/main/src/routers/admin.py
@@ -1,0 +1,58 @@
+from fastapi import Depends, APIRouter
+
+# main db imports
+from backend.main.db.docs.student_profile_doc import (
+    StudentProfileDocument,
+)
+from backend.main.db.models.meeting_model import (
+    CreateMeetingModel,
+    MeetingSearchModel,
+    MeetingModel,
+)
+from backend.main.db.docs.meeting_doc import (
+    document as MeetingDoc,
+    MeetingDocument,
+)
+from backend.main.db.password_generator import generate_random_password
+
+# auth db imports
+from backend.auth.dependencies import (
+    TokenData,
+    get_admin_token_data,
+)
+
+router = APIRouter()
+
+
+# GET routes
+@router.get("/get_student_profiles")
+def get_student_profiles(token_data: TokenData = Depends(get_admin_token_data)):
+    all_profiles = []
+    for profile in StudentProfileDocument.objects():
+        all_profiles.append(profile.dict())
+    return all_profiles
+
+
+# POST routes
+@router.post("/get_meetings")
+async def get_meetings_by_filter(
+    search: MeetingSearchModel, token_data: TokenData = Depends(get_admin_token_data)
+):
+    # TODO: Use the dates field from MeetingSearchModel
+    meetings = []
+    try:
+        for level in search.session_levels:
+            for meeting in MeetingDocument.objects(session_level=level):
+                meetings.append(meeting.admin_dict())
+    except Exception:
+        return {"details": "Error finding meeting"}
+    return meetings
+
+
+@router.post("/create_meeting")
+async def create_meeting(create_meeting: CreateMeetingModel):
+    password = generate_random_password()
+    meeting = MeetingModel(**create_meeting.dict(), password=password, students=[])
+    doc = MeetingDoc(meeting)
+    doc.save()
+    return doc.dict()

--- a/backend/main/src/routers/meeting_router.py
+++ b/backend/main/src/routers/meeting_router.py
@@ -1,3 +1,5 @@
+from pydantic import UUID4
+
 from backend.main.db.models.meeting_model import MeetingModel
 from backend.main.db.docs.meeting_doc import MeetingDocument, document
 from backend.main.db.password_generator import generate_random_password
@@ -14,10 +16,14 @@ from backend.auth.dependencies import (
 router = APIRouter()
 
 
+# Some of these are probably broken now.
+# Sorry, I will try and fix them if you think we should still use them
+
+
 @router.post("/add_meeting")
 async def add_meeting(meeting: MeetingModel):
     password = generate_random_password()
-    meeting.meeting_password = password
+    meeting.password = password
     meeting.students = []
     doc = document(meeting)
     doc.save()
@@ -26,10 +32,10 @@ async def add_meeting(meeting: MeetingModel):
 
 @router.get("get_meeting_by_id")
 async def get_meeting_by_id(
-    meeting_id: str, token_data: TokenData = Depends(get_current_token_data)
+    meeting_id: UUID4, token_data: TokenData = Depends(get_current_token_data)
 ):
     try:
-        meeting = MeetingDocument.objects(id=meeting_id)[0]
+        meeting = MeetingDocument.objects(uuid=meeting_id)[0]
     except Exception:
         return {"details": "Error getting meeting"}
     if meeting is None:
@@ -66,12 +72,12 @@ async def get_all_meetings(token_data: TokenData = Depends(get_current_token_dat
 
 @router.post("/add_student")
 async def add_student(
-    meeting_id: str,
+    meeting_id: UUID4,
     token_data: TokenData = Depends(get_current_token_data),
 ):
     current_user = get_current_user_doc(token_data)
     try:
-        meeting = MeetingDocument.objects(id=meeting_id)[0]
+        meeting = MeetingDocument.objects(uuid=meeting_id)[0]
     except Exception:
         return {"details": "could not find meeting form id"}
 

--- a/backend/main/src/routers/student.py
+++ b/backend/main/src/routers/student.py
@@ -1,10 +1,7 @@
-from pydantic import BaseModel, EmailStr, Field
 from fastapi import Depends, APIRouter
 
 # main db imports
 from backend.main.db.models.student_profile_model import (
-    Student,
-    Guardian,
     StudentProfileModel,
     StudentProfileCreateModel,
 )
@@ -31,14 +28,11 @@ from backend.auth.dependencies import (
 router = APIRouter()
 
 
-class Email(BaseModel):
-    new_email: EmailStr = Field()
-
-
 def get_current_user_doc(token_data: TokenData):
     current_user = None
     try:
         current_user = StudentProfileDocument.objects(uuid=token_data.id)[0]
+    # TODO: raise an HTTP exception instead of just returning details
     except Exception as e:
         print("Exception type:", type(e))
         print("Could not find the user profile.")
@@ -70,115 +64,6 @@ async def add_profile(
     return doc.dict()
 
 
-# PUT routes
-@router.put("/update_email")
-async def update_main_email(
-    email: Email,
-    token_data: TokenData = Depends(get_student_token_data),
-):
-    current_user = get_current_user_doc(token_data)
-    if current_user.email != email.new_email:
-        current_user.email = email.new_email
-    current_user.save()
-    return current_user.dict()
-
-
-@router.put("/update_guardian")
-async def update_student_guardian(
-    guardian: Guardian,
-    token_data: TokenData = Depends(get_student_token_data),
-):
-    current_user = get_current_user_doc(token_data)
-    updated_contact = None
-    i = 0
-    for contact in current_user.guardians:
-        if (
-            contact["first_name"] == guardian.first_name
-            and contact["last_name"] == guardian.last_name
-        ):
-            updated_contact = contact
-            break
-        i += 1
-
-    if updated_contact is None:
-        return {"details": "The contact could not be found."}
-
-    current_user.guardians[i] = guardian.dict()
-
-    current_user.save()
-    return current_user.dict()
-
-
-@router.put("/add_guardian")
-async def add_guardian(
-    guardian: Guardian,
-    token_data: TokenData = Depends(get_student_token_data),
-):
-    current_user = get_current_user_doc(token_data)
-    updated_contact = None
-    for contact in current_user.guardians:
-        if (
-            contact["first_name"] == guardian.first_name
-            and contact["last_name"] == guardian.last_name
-        ):
-            updated_contact = contact
-
-    if updated_contact is not None:
-        return {"details": "The contact is already in the list"}
-
-    current_user.guardians.append(guardian.dict())
-    current_user.save()
-    return current_user.dict()
-
-
-@router.put("/add_student")
-async def add_student(
-    student: Student,
-    token_data: TokenData = Depends(get_student_token_data),
-):
-    current_user = get_current_user_doc(token_data)
-    add_student = None
-    for add in current_user.students:
-        if (
-            add["first_name"] == student.first_name
-            and add["last_name"] == student.last_name
-        ):
-            add_student = add
-
-    if add_student is not None:
-        return {"details": "The student is already in the list"}
-
-    current_user.students.append(student.dict())
-    current_user.save()
-    return current_user.dict()
-
-
-@router.put("/update_student")
-async def update_student(
-    student: Student,
-    token_data: TokenData = Depends(get_student_token_data),
-):
-    current_user = get_current_user_doc(token_data)
-    add_student = None
-    i = 0
-    for add in current_user.students:
-        if (
-            add["first_name"] == student.first_name
-            and add["last_name"] == student.last_name
-        ):
-            add_student = add
-            break
-        i += 1
-
-    if add_student is None:
-        return {"details": "The student could not be found"}
-
-    current_user.students[i] = student.dict()
-
-    current_user.save()
-    return current_user.dict()
-
-
 @router.post("/get_meetings")
 async def get_meetings_by_filter(
     search: MeetingSearchModel, token_data: TokenData = Depends(get_student_token_data)
@@ -189,6 +74,7 @@ async def get_meetings_by_filter(
         for level in search.session_levels:
             for meeting in MeetingDocument.objects(session_level=level):
                 meetings.append(meeting.student_dict())
+    # TODO: raise an HTTP exception instead of just returning details
     except Exception:
         return {"details": "Error finding meeting"}
     return meetings
@@ -199,26 +85,12 @@ async def register_student(
     registration: StudentMeetingRegistration,
     token_data: TokenData = Depends(get_student_token_data),
 ):
-    # Now, i am just requiring student info to register
-    # add_student = []
-    # for student in current_user.students:
-    #     for section in student["section"]:
-    #         if section == meeting.session_level:
-    #             add_student.append(student)
-
-    # for student in add_student:
-    #     add = StudentMeetingInfo(
-    #         first_name=student["first_name"],
-    #         last_name=student["last_name"],
-    #         email=current_user.email,
-    #         guardians=current_user.guardians,
-    #     )
-    #     meeting.students.append(add.dict())
     current_user = get_current_user_doc(token_data)
     try:
         meeting = MeetingDocument.objects(uuid=registration.meeting_id)[0]
+    # TODO: raise an HTTP exception instead of just returning details
     except Exception:
-        return {"details": "could not find meeting form id"}
+        return {"details": "could not find meeting from meeting_id"}
 
     student_info = StudentMeetingInfo(
         first_name=registration.first_name,
@@ -229,6 +101,21 @@ async def register_student(
     )
 
     meeting.students.append(student_info.dict())
-
     meeting.save()
-    return {"details": "Student added to meeting list"}
+    return {
+        "details": f"Student {student_info.first_name} {student_info.last_name} added to meeting list"
+    }
+
+
+# PUT routes
+@router.put("/update_profile")
+async def update_profile(
+    new_profile: StudentProfileCreateModel,
+    token_data: TokenData = Depends(get_student_token_data),
+):
+    current_user = get_current_user_doc(token_data)
+    current_user["email"] = new_profile.email
+    current_user["guardians"] = new_profile.guardians
+    current_user["students"] = new_profile.students
+    current_user.save()
+    return current_user.dict()

--- a/backend/main/src/routers/student.py
+++ b/backend/main/src/routers/student.py
@@ -3,6 +3,8 @@ from fastapi import Depends, APIRouter
 
 # main db imports
 from backend.main.db.models.student_profile_model import (
+    Student,
+    Guardian,
     StudentProfileModel,
     StudentProfileCreateModel,
 )
@@ -10,7 +12,15 @@ from backend.main.db.docs.student_profile_doc import (
     document as StudentDoc,
     StudentProfileDocument,
 )
-from backend.main.db.models.student_profile_model import Guardian, Student
+from backend.main.db.models.meeting_model import (
+    MeetingSearchModel,
+    StudentMeetingRegistration,
+    StudentMeetingInfo,
+)
+from backend.main.db.docs.meeting_doc import (
+    MeetingDocument,
+)
+
 
 # auth db imports
 from backend.auth.dependencies import (
@@ -38,18 +48,19 @@ def get_current_user_doc(token_data: TokenData):
 # GET routes
 @router.get("/get_my_profile")
 def get_current_user_profile(token_data: TokenData = Depends(get_student_token_data)):
-    user_doc = None
-    try:
-        user_doc = StudentProfileDocument.objects(uuid=token_data.id)[0]
-    except Exception as e:
-        print("Exception type:", type(e))
-        print("Could not find the user profile.")
-    return user_doc.dict()
+    current_user = get_current_user_doc(token_data)
+    return current_user.dict()
+
+
+@router.get("/get_students")
+def get_student_names(token_data: TokenData = Depends(get_student_token_data)):
+    current_user = get_current_user_doc(token_data)
+    return current_user["students"]
 
 
 # POST routes
-@router.post("/add_student_profile")
-async def add_student_profile(
+@router.post("/add_profile")
+async def add_profile(
     profile: StudentProfileCreateModel,
     token_data: TokenData = Depends(get_student_token_data),
 ):
@@ -60,7 +71,7 @@ async def add_student_profile(
 
 
 # PUT routes
-@router.put("/update_student_profile")
+@router.put("/update_email")
 async def update_main_email(
     email: Email,
     token_data: TokenData = Depends(get_student_token_data),
@@ -72,7 +83,7 @@ async def update_main_email(
     return current_user.dict()
 
 
-@router.put("/update_student_guardian")
+@router.put("/update_guardian")
 async def update_student_guardian(
     guardian: Guardian,
     token_data: TokenData = Depends(get_student_token_data),
@@ -98,8 +109,8 @@ async def update_student_guardian(
     return current_user.dict()
 
 
-@router.put("/add_student_guardian")
-async def add_student_guardian(
+@router.put("/add_guardian")
+async def add_guardian(
     guardian: Guardian,
     token_data: TokenData = Depends(get_student_token_data),
 ):
@@ -166,3 +177,58 @@ async def update_student(
 
     current_user.save()
     return current_user.dict()
+
+
+@router.post("/get_meetings")
+async def get_meetings_by_filter(
+    search: MeetingSearchModel, token_data: TokenData = Depends(get_student_token_data)
+):
+    # TODO: Use the dates field from MeetingSearchModel
+    meetings = []
+    try:
+        for level in search.session_levels:
+            for meeting in MeetingDocument.objects(session_level=level):
+                meetings.append(meeting.student_dict())
+    except Exception:
+        return {"details": "Error finding meeting"}
+    return meetings
+
+
+@router.post("/register_for_meeting")
+async def register_student(
+    registration: StudentMeetingRegistration,
+    token_data: TokenData = Depends(get_student_token_data),
+):
+    # Now, i am just requiring student info to register
+    # add_student = []
+    # for student in current_user.students:
+    #     for section in student["section"]:
+    #         if section == meeting.session_level:
+    #             add_student.append(student)
+
+    # for student in add_student:
+    #     add = StudentMeetingInfo(
+    #         first_name=student["first_name"],
+    #         last_name=student["last_name"],
+    #         email=current_user.email,
+    #         guardians=current_user.guardians,
+    #     )
+    #     meeting.students.append(add.dict())
+    current_user = get_current_user_doc(token_data)
+    try:
+        meeting = MeetingDocument.objects(uuid=registration.meeting_id)[0]
+    except Exception:
+        return {"details": "could not find meeting form id"}
+
+    student_info = StudentMeetingInfo(
+        first_name=registration.first_name,
+        last_name=registration.last_name,
+        email=current_user["email"],
+        guardians=current_user["guardians"],
+        account_uuid=token_data.id,
+    )
+
+    meeting.students.append(student_info.dict())
+
+    meeting.save()
+    return {"details": "Student added to meeting list"}


### PR DESCRIPTION
- Routes now check the roles contained in the tokens
- get profile route is now a GET request (this was done by adding to the student profile model stuff)
- completely refactored user_router and meeting_router.  this is now split into a student router and an admin router.  I have left the old files,
and we can remove them after more testing.  
- added a lot to the meeting model and meeting document, e.g. added an enum for session level, created more models for meeting creating and student registration
- admin and student accounts now receive appropriate information from the get meetings route.

@jiachengzhang1 and @athanwalker  **We will need to update the routes that we worked on today.  Shouldn't be too hard, but I can meet with you guys to do that if you would like** 
For the frontend, here are an overview of the changes:

- `user_router/get_my_profile` now located at `student/get_profile`
- `user_router/add_student_profile` now located at `student/add_profile`
  - the `section` field is now a list of SessionLevel enums, valid values for the enum are `"junior_a"`, `"junior_b"`, `"senior"` (we can modify this)
- update routes for student profile now located at `student/update_profile` a single put request that accepts all fields like `add_profile`
- student has a `student/get_students` route.  i thought this would be nice for populating the meeting registration form, but is probably unnecesary
- meeting requests at `meeting_router/` are now split into `student/` and `admin/`
-  both student and admin have a route `get_meetings` which in the request body takes
   - a list `session_levels` which is a list of SessionLevel enums
   - a list of `dates` but filtering on dates is not implemented yet
   - different info is returned based on being a student or admin
- student has a `student/register_for_meeting` route which in the request body takes
  - `meeting_id` which is type uuid
  - `first_name` of the registering student
  - `last_name` of the registering student
- admin has  `admin/create_meeting` route  which in the request body takes
  -   `date_and_time`: datetime 
  -  `duration` datetime
  - `zoom_link`:` str`
  - `session_level`: `SessionLevel`
  - `topic`: `Optional[str]` 
  - `miro_link`: `Optional[str]`
 - admin has a `admin/get_student_profiles` route which returns all student profiles


I have tested the following:

1. admin creating a meeting
2. student searching for meetings according to session_level (the get_meetings route also accepts dates in its request body, but filtering by that is not implemented yet)
3. student registering for meeting
4. admin searching for meetings and getting meeting info which includes list of students who have registered

The meeting now stores a `date_and_time` datetime and `duration` datetime.  We can adjust that as needed.



