### PR TITLE
Refactor student into its own document

### DIFF
--- a/backend/main/db/docs/student_doc.py
+++ b/backend/main/db/docs/student_doc.py
@@ -1,16 +1,24 @@
-from mongoengine import Document, ListField, QuerySet, StringField, IntField, UUIDField, DictField
+from mongoengine import (
+    Document,
+    QuerySet,
+    StringField,
+    IntField,
+    UUIDField,
+    DictField,
+)
 
-# TODO: What does QuerySet do?
 
 from backend.main.db.models.student_models import (
     StudentModel,
 )
 
 
+# TODO: What does QuerySet do?
+class StudentQuerySet(QuerySet):
+    pass
+
+
 def document(model: StudentModel):
-    print("------------------")
-    print("Student.dict():", model.dict())
-    print("------------------")
     doc = StudentDocument(**model.dict())
     return doc
 
@@ -23,6 +31,7 @@ class StudentDocument(Document):
     last_name = StringField(required=True)
     grade = StringField(required=True)
     age = IntField(required=True)
+    # TODO: Change meetings_registered?
     meetings_registered = DictField()
     meeting_counts = DictField(required=True)
 
@@ -41,4 +50,3 @@ class StudentDocument(Document):
             "meetings_registered": self.meetings_registered,
             "meeting_counts": self.meeting_counts,
         }
-

--- a/backend/main/db/docs/student_doc.py
+++ b/backend/main/db/docs/student_doc.py
@@ -1,4 +1,4 @@
-from mongoengine import Document, ListField, QuerySet, StringField, IntField, UUIDField
+from mongoengine import Document, ListField, QuerySet, StringField, IntField, UUIDField, DictField
 
 # TODO: What does QuerySet do?
 
@@ -23,16 +23,16 @@ class StudentDocument(Document):
     last_name = StringField(required=True)
     grade = StringField(required=True)
     age = IntField(required=True)
-    meetings_registered = ListField(required=True)
-    meeting_counts = ListField(required=True)
+    meetings_registered = DictField()
+    meeting_counts = DictField(required=True)
 
     meta = {
         "db_alias": "student-db",
-        "indexes": ["email", "uuid"],
     }
 
     def dict(self):
         return {
+            "id": str(self.id),
             "profile_uuid": self.profile_uuid,
             "first_name": self.first_name,
             "last_name": self.last_name,

--- a/backend/main/db/docs/student_doc.py
+++ b/backend/main/db/docs/student_doc.py
@@ -31,7 +31,7 @@ class StudentDocument(Document):
     last_name = StringField(required=True)
     grade = StringField(required=True)
     age = IntField(required=True)
-    # TODO: Change meetings_registered?
+    # dictionary of the form (meeting uuid, attended (True/False))
     meetings_registered = DictField()
     meeting_counts = DictField(required=True)
 

--- a/backend/main/db/docs/student_docs.py
+++ b/backend/main/db/docs/student_docs.py
@@ -1,0 +1,44 @@
+from mongoengine import Document, ListField, QuerySet, StringField, IntField, UUIDField
+
+# TODO: What does QuerySet do?
+
+from backend.main.db.models.student_models import (
+    StudentModel,
+)
+
+
+def document(model: StudentModel):
+    print("------------------")
+    print("Student.dict():", model.dict())
+    print("------------------")
+    doc = StudentDocument(**model.dict())
+    return doc
+
+
+class StudentDocument(Document):
+    _model = StudentModel
+
+    profile_uuid = UUIDField(required=True)
+    first_name = StringField(required=True)
+    last_name = StringField(required=True)
+    grade = StringField(required=True)
+    age = IntField(required=True)
+    meetings_registered = ListField(required=True)
+    meeting_counts = ListField(required=True)
+
+    meta = {
+        "db_alias": "student-db",
+        "indexes": ["email", "uuid"],
+    }
+
+    def dict(self):
+        return {
+            "profile_uuid": self.profile_uuid,
+            "first_name": self.first_name,
+            "last_name": self.last_name,
+            "grade": self.grade,
+            "age": self.age,
+            "meetings_registered": self.meetings_registered,
+            "meeting_counts": self.meeting_counts,
+        }
+

--- a/backend/main/db/docs/student_profile_doc.py
+++ b/backend/main/db/docs/student_profile_doc.py
@@ -11,7 +11,7 @@ from backend.main.db.models.student_profile_model import (
     StudentProfileModel,
 )
 
-from backend.main.db.docs.student_docs import StudentDocument
+from backend.main.db.docs.student_doc import StudentDocument, document as StudentDoc
 
 
 class StudentProfileQuerySet(QuerySet):
@@ -22,7 +22,20 @@ def document(model: StudentProfileModel):
     print("------------------")
     print("StudentProfileModel.dict():", model.dict())
     print("------------------")
-    doc = StudentProfileDocument(**model.dict())
+    # create StudentDocument for each student in the student profile
+    student_documents = []
+    for student in model.students:
+        student_document = StudentDoc(student)
+        student_document.save()
+        student_documents.append(student_document)
+
+    guardians = [g.dict() for g in model.guardians]
+    doc = StudentProfileDocument(
+        uuid=model.uuid,
+        email=model.email,
+        students=student_documents,
+        guardians=guardians,
+    )
     return doc
 
 
@@ -41,9 +54,10 @@ class StudentProfileDocument(Document):
     }
 
     def dict(self):
+        students = [s.dict() for s in self.students]
         return {
             "uuid": self.uuid,
             "email": self.email,
-            "student_list": self.students,
+            "student_list": students,
             "guardians": self.guardians,
         }

--- a/backend/main/db/docs/student_profile_doc.py
+++ b/backend/main/db/docs/student_profile_doc.py
@@ -19,9 +19,6 @@ class StudentProfileQuerySet(QuerySet):
 
 
 def document(model: StudentProfileModel):
-    print("------------------")
-    print("StudentProfileModel.dict():", model.dict())
-    print("------------------")
     # create StudentDocument for each student in the student profile
     student_documents = []
     for student in model.students:
@@ -42,6 +39,7 @@ def document(model: StudentProfileModel):
 class StudentProfileDocument(Document):
     _model = StudentProfileModel
 
+    # TODO: change `student_list` to `students`?
     uuid = UUIDField(required=True)
     email = EmailField(required=True)
     students = ListField(ReferenceField(StudentDocument))

--- a/backend/main/db/docs/student_profile_doc.py
+++ b/backend/main/db/docs/student_profile_doc.py
@@ -1,8 +1,17 @@
-from mongoengine import Document, ListField, EmailField, QuerySet, UUIDField
+from mongoengine import (
+    Document,
+    ListField,
+    EmailField,
+    QuerySet,
+    UUIDField,
+    ReferenceField,
+)
 
 from backend.main.db.models.student_profile_model import (
     StudentProfileModel,
 )
+
+from backend.main.db.docs.student_docs import StudentDocument
 
 
 class StudentProfileQuerySet(QuerySet):
@@ -10,6 +19,9 @@ class StudentProfileQuerySet(QuerySet):
 
 
 def document(model: StudentProfileModel):
+    print("------------------")
+    print("StudentProfileModel.dict():", model.dict())
+    print("------------------")
     doc = StudentProfileDocument(**model.dict())
     return doc
 
@@ -19,14 +31,13 @@ class StudentProfileDocument(Document):
 
     uuid = UUIDField(required=True)
     email = EmailField(required=True)
-    students = ListField(required=True)
+    students = ListField(ReferenceField(StudentDocument))
     guardians = ListField(required=True)
 
-    # QUESTION: should we add uuid to indexes?
     meta = {
         "query_class": StudentProfileQuerySet,
         "db_alias": "student-db",
-        "indexes": ["email"],
+        "indexes": ["email", "uuid"],
     }
 
     def dict(self):

--- a/backend/main/db/mixins.py
+++ b/backend/main/db/mixins.py
@@ -2,12 +2,25 @@ from enum import Enum
 from typing import Any, Optional
 
 from pydantic import BaseModel, Field, validator
+from bson.objectid import ObjectId
 
 
 class SessionLevel(str, Enum):
     junior_a = "junior_a"
     junior_b = "junior_b"
     senior = "senior"
+
+
+class PydanticObjectId(ObjectId):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        if not isinstance(v, ObjectId):
+            raise TypeError("ObjectId required")
+        return str(v)
 
 
 class IdMixin(BaseModel):

--- a/backend/main/db/mixins.py
+++ b/backend/main/db/mixins.py
@@ -1,8 +1,8 @@
 from enum import Enum
 from typing import Any, Optional
 
-from pydantic import BaseModel, Field, validator
-from bson.objectid import ObjectId
+from pydantic import BaseModel, Field, validator, BaseConfig
+from bson.objectid import ObjectId, InvalidId
 
 
 class SessionLevel(str, Enum):
@@ -11,16 +11,23 @@ class SessionLevel(str, Enum):
     senior = "senior"
 
 
-class PydanticObjectId(ObjectId):
+class PydanticObjectId(str):
     @classmethod
     def __get_validators__(cls):
         yield cls.validate
 
     @classmethod
     def validate(cls, v):
-        if not isinstance(v, ObjectId):
-            raise TypeError("ObjectId required")
+        try:
+            ObjectId(str(v))
+        except InvalidId:
+            raise ValueError("Not a valid ObjectId")
         return str(v)
+
+    class Config(BaseConfig):
+        json_encoders = {
+            ObjectId: lambda oid: str(oid),
+        }
 
 
 class IdMixin(BaseModel):

--- a/backend/main/db/models/meeting_model.py
+++ b/backend/main/db/models/meeting_model.py
@@ -4,23 +4,22 @@ from uuid import uuid4
 
 from pydantic import Field, BaseModel, EmailStr, UUID4
 
-from backend.main.db.mixins import SessionLevel
+from backend.main.db.mixins import SessionLevel, PydanticObjectId
 from backend.main.db.models.student_profile_model import Guardian
 
 
 class StudentMeetingRegistration(BaseModel):
     meeting_id: UUID4 = Field()
-    first_name: str = Field()
-    last_name: str = Field()
+    student_id: PydanticObjectId = Field()
+    registered: bool
 
 
 class StudentMeetingInfo(BaseModel):
-    first_name: str = Field()
-    last_name: str = Field()
+    student_id: PydanticObjectId = Field()
     email: EmailStr = Field()
     guardians: List[Guardian] = Field()
     account_uuid: UUID4 = Field()
-    attended: Optional[bool] = Field(default=False)
+    attended: bool = Field(default=False)
 
 
 class CreateMeetingModel(BaseModel):

--- a/backend/main/db/models/student_models.py
+++ b/backend/main/db/models/student_models.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 from pydantic import BaseModel, Field, EmailStr, UUID4
 
-from backend.main.db.mixins import SessionLevel
+from backend.main.db.mixins import PydanticObjectId, SessionLevel
 
 
 class StudentMeetingCounter(BaseModel):
@@ -15,6 +15,7 @@ class StudentMeetingCounter(BaseModel):
 class StudentMeetingRegistration(BaseModel):
     meeting_uuid: UUID4 = Field()
     attended: bool = False
+
 
 class StudentGrade(str, Enum):
     pre_k = "PreK"
@@ -32,15 +33,25 @@ class StudentGrade(str, Enum):
     eleven = "11"
     twelve = "12"
 
+
 class StudentCreateModel(BaseModel):
     first_name: str = Field()
     last_name: str = Field()
     grade: StudentGrade = Field()
     age: int = Field()
 
+class StudentUpdateModel(StudentCreateModel):
+    id: PydanticObjectId
+
+
 class StudentModel(StudentCreateModel):
     profile_uuid: UUID4 = Field()
-    meetings_registered: List[StudentMeetingRegistration] = Field()
+    # dictionary of the form (meeting uuid, attended)
+    meetings_registered: Dict[UUID4, bool] = {}
     # meeting_counts is a convenience to track the number
     # of meetings registered and attended for each `SessionLevel`
-    meeting_counts: List[Dict[SessionLevel, StudentMeetingCounter]] = Field()
+    meeting_counts: Dict[SessionLevel, StudentMeetingCounter] = {
+        SessionLevel.junior_a: StudentMeetingCounter(),
+        SessionLevel.junior_b: StudentMeetingCounter(),
+        SessionLevel.senior: StudentMeetingCounter(),
+    }

--- a/backend/main/db/models/student_models.py
+++ b/backend/main/db/models/student_models.py
@@ -1,0 +1,46 @@
+from typing import List, Dict, Tuple
+from enum import Enum
+
+from pydantic import BaseModel, Field, EmailStr, UUID4
+
+from backend.main.db.mixins import SessionLevel
+
+
+class StudentMeetingCounter(BaseModel):
+    attended: int = 0
+    registered: int = 0
+    # TODO: Add a validation that attended <= registered
+
+
+class StudentMeetingRegistration(BaseModel):
+    meeting_uuid: UUID4 = Field()
+    attended: bool = False
+
+class StudentGrade(str, Enum):
+    pre_k = "PreK"
+    k = "K"
+    one = "1"
+    two = "2"
+    three = "3"
+    four = "4"
+    five = "5"
+    six = "6"
+    seven = "7"
+    eight = "8"
+    nine = "9"
+    ten = "10"
+    eleven = "11"
+    twelve = "12"
+
+class StudentCreateModel(BaseModel):
+    first_name: str = Field()
+    last_name: str = Field()
+    grade: StudentGrade = Field()
+    age: int = Field()
+
+class StudentModel(StudentCreateModel):
+    profile_uuid: UUID4 = Field()
+    meetings_registered: List[StudentMeetingRegistration] = Field()
+    # meeting_counts is a convenience to track the number
+    # of meetings registered and attended for each `SessionLevel`
+    meeting_counts: List[Dict[SessionLevel, StudentMeetingCounter]] = Field()

--- a/backend/main/db/models/student_models.py
+++ b/backend/main/db/models/student_models.py
@@ -1,7 +1,7 @@
-from typing import List, Dict, Tuple
+from typing import Dict
 from enum import Enum
 
-from pydantic import BaseModel, Field, EmailStr, UUID4
+from pydantic import BaseModel, Field, UUID4
 
 from backend.main.db.mixins import PydanticObjectId, SessionLevel
 
@@ -40,13 +40,14 @@ class StudentCreateModel(BaseModel):
     grade: StudentGrade = Field()
     age: int = Field()
 
+
 class StudentUpdateModel(StudentCreateModel):
     id: PydanticObjectId
 
 
 class StudentModel(StudentCreateModel):
     profile_uuid: UUID4 = Field()
-    # dictionary of the form (meeting uuid, attended)
+    # dictionary of the form (meeting uuid, attended (True/False))
     meetings_registered: Dict[UUID4, bool] = {}
     # meeting_counts is a convenience to track the number
     # of meetings registered and attended for each `SessionLevel`

--- a/backend/main/db/models/student_profile_model.py
+++ b/backend/main/db/models/student_profile_model.py
@@ -1,9 +1,9 @@
-from typing import List
+from typing import List, Dict
 
 from pydantic import BaseModel, Field, EmailStr, UUID4
 
 from backend.main.db.mixins import SessionLevel, PydanticObjectId
-from backend.main.db.models.student_models import StudentCreateModel, StudentModel
+from backend.main.db.models.student_models import StudentCreateModel, StudentModel, StudentUpdateModel
 
 
 class Guardian(BaseModel):
@@ -11,6 +11,9 @@ class Guardian(BaseModel):
     last_name: str = Field()
     phone_number: str = Field()
     email: EmailStr = Field()
+
+class Student(BaseModel):
+    pass
 
 
 # this is the model for the API since
@@ -23,8 +26,17 @@ class StudentProfileCreateModel(BaseModel):
     mailing_lists: List[SessionLevel] = Field()
 
 
+# The UpdateModel uses a dict for students to match up
+# students with their ids
+class StudentProfileUpdateModel(BaseModel):
+    email: EmailStr = Field()
+    students: List[StudentUpdateModel] = Field()
+    guardians: List[Guardian] = Field()
+    mailing_lists: List[SessionLevel] = Field()
+
 class StudentProfileModel(BaseModel):
     uuid: UUID4 = Field()
-    students: List[PydanticObjectId] = Field()
+    email: EmailStr = Field()
+    students: List[StudentModel] = Field()
     guardians: List[Guardian] = Field()
     mailing_lists: List[SessionLevel] = Field()

--- a/backend/main/db/models/student_profile_model.py
+++ b/backend/main/db/models/student_profile_model.py
@@ -2,7 +2,8 @@ from typing import List
 
 from pydantic import BaseModel, Field, EmailStr, UUID4
 
-from backend.main.db.mixins import SessionLevel
+from backend.main.db.mixins import SessionLevel, PydanticObjectId
+from backend.main.db.models.student_models import StudentCreateModel, StudentModel
 
 
 class Guardian(BaseModel):
@@ -12,22 +13,18 @@ class Guardian(BaseModel):
     email: EmailStr = Field()
 
 
-class Student(BaseModel):
-    first_name: str = Field()
-    last_name: str = Field()
-    grade: int = Field()
-    age: int = Field()
-    section: List[SessionLevel] = Field()
-
-
 # this is the model for the API since
 # we will use the uuid from the token
 # for the StudentProfileModel
 class StudentProfileCreateModel(BaseModel):
     email: EmailStr = Field()
-    students: List[Student]
-    guardians: List[Guardian]
+    students: List[StudentCreateModel] = Field()
+    guardians: List[Guardian] = Field()
+    mailing_lists: List[SessionLevel] = Field()
 
 
-class StudentProfileModel(StudentProfileCreateModel):
+class StudentProfileModel(BaseModel):
     uuid: UUID4 = Field()
+    students: List[PydanticObjectId] = Field()
+    guardians: List[Guardian] = Field()
+    mailing_lists: List[SessionLevel] = Field()

--- a/backend/main/db/models/student_profile_model.py
+++ b/backend/main/db/models/student_profile_model.py
@@ -1,9 +1,13 @@
-from typing import List, Dict
+from typing import List
 
 from pydantic import BaseModel, Field, EmailStr, UUID4
 
-from backend.main.db.mixins import SessionLevel, PydanticObjectId
-from backend.main.db.models.student_models import StudentCreateModel, StudentModel, StudentUpdateModel
+from backend.main.db.mixins import SessionLevel
+from backend.main.db.models.student_models import (
+    StudentCreateModel,
+    StudentModel,
+    StudentUpdateModel,
+)
 
 
 class Guardian(BaseModel):
@@ -11,6 +15,7 @@ class Guardian(BaseModel):
     last_name: str = Field()
     phone_number: str = Field()
     email: EmailStr = Field()
+
 
 class Student(BaseModel):
     pass
@@ -33,6 +38,7 @@ class StudentProfileUpdateModel(BaseModel):
     students: List[StudentUpdateModel] = Field()
     guardians: List[Guardian] = Field()
     mailing_lists: List[SessionLevel] = Field()
+
 
 class StudentProfileModel(BaseModel):
     uuid: UUID4 = Field()

--- a/backend/main/src/app.py
+++ b/backend/main/src/app.py
@@ -15,7 +15,6 @@ from fastapi.middleware.cors import CORSMiddleware
 import uvicorn
 
 # main db imports
-from backend.main.src.routers import user_router, meeting_router
 from backend.main.src.routers import student, admin
 from backend.connect_to_mongodb import connect_to_mongodb, connect_to_auth_db
 
@@ -33,10 +32,6 @@ TESTING = True
 
 app = FastAPI()
 
-
-# TODO: delete these
-# app.include_router(user_router.router, prefix="/user_router", tags=["Users"])
-# app.include_router(meeting_router.router, prefix="/meetings_router", tags=["Meetings"])
 
 app.include_router(student.router, prefix="/student", tags=["Students"])
 app.include_router(admin.router, prefix="/admin", tags=["Admin"])

--- a/backend/main/src/app.py
+++ b/backend/main/src/app.py
@@ -34,8 +34,9 @@ TESTING = True
 app = FastAPI()
 
 
-app.include_router(user_router.router, prefix="/user_router", tags=["Users"])
-app.include_router(meeting_router.router, prefix="/meetings_router", tags=["Meetings"])
+# TODO: delete these
+# app.include_router(user_router.router, prefix="/user_router", tags=["Users"])
+# app.include_router(meeting_router.router, prefix="/meetings_router", tags=["Meetings"])
 
 app.include_router(student.router, prefix="/student", tags=["Students"])
 app.include_router(admin.router, prefix="/admin", tags=["Admin"])

--- a/backend/main/src/routers/student.py
+++ b/backend/main/src/routers/student.py
@@ -8,11 +8,9 @@ from backend.main.db.models.student_profile_model import (
 )
 from backend.main.db.models.student_models import (
     StudentModel,
-    StudentCreateModel,
     StudentUpdateModel,
 )
 from backend.main.db.docs.student_doc import (
-    document as StudentDoc,
     StudentDocument,
 )
 from backend.main.db.docs.student_profile_doc import (
@@ -62,13 +60,14 @@ def get_student_meeting_index(meeting_doc, first, last):
 
 
 def remove_student_from_meeting(meeting_doc, student_id):
+    # TODO: Update StudentDocument meeting info to reflect changes!
     index = -1
     for i, registration in enumerate(meeting_doc.students):
         if registration["student_id"] == student_id:
             index = i
             break
 
-    del meeting_doc.students[i]
+    del meeting_doc.students[index]
     meeting_doc.save()
 
 
@@ -199,7 +198,8 @@ async def update_student(
             detail="Invalid meeting id",
         )
 
-    if registration.registered == False:
+    if not registration.registered:
+        # TODO: Update StudentDocument meeting info to reflect changes!
         remove_student_from_meeting(meeting_doc, registration.student_id)
         return {
             "details": f"Student with id {registration.student_id} removed from meeting list"
@@ -213,6 +213,10 @@ async def update_student(
     )
     meeting_doc.students.append(student_info.dict())
     meeting_doc.save()
+
+    # Update StudentDocument
+    student.meetings_registered[str(registration.meeting_id)] = True
+    student.save()
     return {
         "details": f"Student with id {registration.student_id} added to meeting list"
     }


### PR DESCRIPTION
- I have made a separate Student Document to store on the database that is referenced by the Student Profile.
- I have removed the `session_level` from the student part and placed it in the profile as an enum (only values "PreK", "K", "1", ..."12" are allowed)
- `add_profile` route shouldn't have changed much
- `update_profile` route is changed to include Student IDs, **I do not currently see how to handle adding students in this route**
- `get_meetings` route is slightly changed
- `update_student_for_meeting_route` is also slightly changed

I tested creating students throuhg the profile, updating a single student, getting meetings, and registering/deregistering students and they worked.