### PR TITLE
Add S3 stuff to make presigned urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 Pipfile
 Pipfile.lock
 backend/.coverage
+backend/auth/aws-config.toml
 frontend/coverage

--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -15,6 +15,7 @@ passlib = {version = "<1.8.0,>=1.7.4", extras = ["bcrypt"]}
 pydantic = {version = ">=1.8.1,<1.9.0", extras = ["email"]}
 requests = "<2.26,>=2.25.1"
 python-multipart = "*"
+boto3 = "<1.18,>=1.17.46"
 
 [dev-packages]
 pytest = "*"

--- a/backend/Pipfile.lock
+++ b/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a53be00aa870024a9de3ab038f18dd9924d37e94a6cb826875eba7108f58ccec"
+            "sha256": "aec33aebb87a1c0848c341ac07453796bd20602c89e99b49f2edbc2d522ce5c6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -27,6 +27,22 @@
                 "sha256:cdcdcb3972027f83fe24a48b1e90ea4b584d35f1cc279d76de6fc4b13376239d"
             ],
             "version": "==3.2.0"
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:070c1c4fb75cb3d599e2eb520a50d8e763080f6c06d9de77e9773c36442f23e9",
+                "sha256:5dee15bf961ea584d681fae42c50034c839717e7454c3da90cb57a6c52e97532"
+            ],
+            "index": "pypi",
+            "version": "==1.17.46"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:50bbc3e9341c7daa8219db98c38f26012a151ca88fa260148e5bf3adcbcb9541",
+                "sha256:8cd22cd9dd3852c58dad714950b3fb62316d73c18c4eaf90eda1c677ab5e379b"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.20.46"
         },
         "certifi": {
             "hashes": [
@@ -156,6 +172,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
+                "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.0"
         },
         "mongoengine": {
             "hashes": [
@@ -311,6 +335,14 @@
             "index": "pypi",
             "version": "==3.11.3"
         },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.1"
+        },
         "python-jose": {
             "extras": [
                 "cryptography"
@@ -344,6 +376,13 @@
             ],
             "markers": "python_version >= '3.5' and python_version < '4'",
             "version": "==4.7.2"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:5d48b1fd2232141a9d5fb279709117aaba506cacea7f86f11bc392f06bfa8fc2",
+                "sha256:c5dadf598762899d8cfaecf68eba649cd25b0ce93b6c954b156aaa3eed160547"
+            ],
+            "version": "==0.3.6"
         },
         "six": {
             "hashes": [

--- a/backend/main/db/docs/meeting_doc.py
+++ b/backend/main/db/docs/meeting_doc.py
@@ -6,7 +6,7 @@ from mongoengine import (
     DateTimeField,
     QuerySet,
     UUIDField,
-    URLField,
+    BooleanField,
 )
 
 
@@ -33,7 +33,8 @@ class MeetingDocument(Document):
     students = ListField(required=False)
     coordinator_notes = StringField(reguired=False)
     student_notes = StringField(reguired=False)
-    materials_link = URLField(required=False)
+    materials_uploaded = BooleanField(required=False)
+    materials_object_name = StringField(required=False)
 
     meta = {
         "query_class": MeetingQuerySet,
@@ -51,7 +52,7 @@ class MeetingDocument(Document):
             "topic": self.topic,
             "session_level": self.session_level,
             "student_notes": self.student_notes,
-            "materials_link": self.materials_link,
+            "materials_uploaded": self.materials_uploaded,
         }
 
     def admin_dict(self):
@@ -67,7 +68,7 @@ class MeetingDocument(Document):
             "students": self.students,
             "coordinator_notes": self.coordinator_notes,
             "student_notes": self.student_notes,
-            "materials_link": self.materials_link,
+            "materials_uploaded": self.materials_uploaded,
         }
 
     def dict(self):
@@ -83,5 +84,5 @@ class MeetingDocument(Document):
             "students": self.students,
             "coordinator_notes": self.coordinator_notes,
             "student_notes": self.student_notes,
-            "materials_link": self.materials_link,
+            "materials_uploaded": self.materials_uploaded,
         }

--- a/backend/main/db/docs/student_doc.py
+++ b/backend/main/db/docs/student_doc.py
@@ -6,7 +6,6 @@ from mongoengine import (
     IntField,
     UUIDField,
     DictField,
-    URLField,
 )
 
 
@@ -37,7 +36,7 @@ class StudentDocument(Document):
     meetings_registered = DictField()
     meeting_counts = DictField(required=True)
     verification_status = BooleanField(required=False)
-    consent_form_link = URLField(required=False)
+    consent_form_object_name = StringField(required=False)
 
     meta = {
         "db_alias": "student-db",
@@ -54,5 +53,5 @@ class StudentDocument(Document):
             "meetings_registered": self.meetings_registered,
             "meeting_counts": self.meeting_counts,
             "verification_status": self.verification_status,
-            "consent_form_link": self.consent_form_link,
+            "consent_form_object_name": self.consent_form_object_name,
         }

--- a/backend/main/db/mixins.py
+++ b/backend/main/db/mixins.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, Dict, List
 
 from pydantic import BaseModel, Field, validator, BaseConfig
 from bson.objectid import ObjectId, InvalidId
@@ -28,6 +28,12 @@ class PydanticObjectId(str):
         json_encoders = {
             ObjectId: lambda oid: str(oid),
         }
+
+
+class PresignedPostUrlInfo(BaseModel):
+    fields: Optional[Dict[str, str]] = Field(None, title="This is optional")
+    conditions: Optional[List] = Field(None, title="This is optional")
+    object_name: str
 
 
 class IdMixin(BaseModel):

--- a/backend/main/db/models/meeting_model.py
+++ b/backend/main/db/models/meeting_model.py
@@ -2,7 +2,7 @@ from typing import Optional, List
 from datetime import datetime, date
 from uuid import uuid4
 
-from pydantic import Field, BaseModel, EmailStr, UUID4, AnyUrl
+from pydantic import Field, BaseModel, EmailStr, UUID4
 
 from backend.main.db.mixins import SessionLevel, PydanticObjectId
 from backend.main.db.models.student_profile_model import Guardian
@@ -37,7 +37,8 @@ class CreateMeetingModel(BaseModel):
     miro_link: Optional[str] = Field()
     coordinator_notes: Optional[str] = Field(default=None)
     student_notes: Optional[str] = Field(default=None)
-    materials_link: Optional[AnyUrl] = Field(default=None)
+    materials_uploaded: Optional[bool] = Field(default=False)
+    materials_object_name: Optional[str] = Field(default=None)
 
 
 class MeetingModel(CreateMeetingModel):
@@ -47,6 +48,10 @@ class MeetingModel(CreateMeetingModel):
 
 
 class UpdateMeeting(CreateMeetingModel):
+    meeting_id: UUID4 = Field()
+
+
+class MeetingIdModel(BaseModel):
     meeting_id: UUID4 = Field()
 
 

--- a/backend/main/db/models/student_models.py
+++ b/backend/main/db/models/student_models.py
@@ -1,7 +1,7 @@
 from typing import Dict, Optional
 from enum import Enum
 
-from pydantic import BaseModel, Field, UUID4, AnyUrl
+from pydantic import BaseModel, Field, UUID4
 
 from backend.main.db.mixins import PydanticObjectId, SessionLevel
 
@@ -46,7 +46,7 @@ class StudentCreateModel(BaseModel):
     grade: StudentGrade = Field()
     age: int = Field()
     verification_status: bool = False
-    consent_form_link: Optional[AnyUrl] = None
+    consent_form_object_name: Optional[str] = None
 
 
 class StudentUpdateModel(StudentCreateModel):

--- a/backend/main/src/app.py
+++ b/backend/main/src/app.py
@@ -85,8 +85,8 @@ async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends(
     return {"access_token": access_token, "token_type": "bearer"}
 
 
-@app.post("/presigned_url_for_url")
-async def generate_student_consent_form_url(
+@app.post("/presigned_url_for_upload")
+async def generate_presigned_post_url(
     info: PresignedPostUrlInfo, token_data: TokenData = Depends(get_current_token_data)
 ):
     response = create_presigned_post(info.object_name, info.fields, info.conditions)

--- a/backend/main/src/app.py
+++ b/backend/main/src/app.py
@@ -22,10 +22,12 @@ from backend.main.db.mixins import PresignedPostUrlInfo
 # auth db imports
 from backend.auth.dependencies import (
     Token,
+    TokenData,
     create_access_token,
     authenticate_user,
     ACCESS_TOKEN_EXPIRE_MIN,
     create_presigned_post,
+    get_current_token_data,
 )
 from backend.auth.db.main import get_user_by_email
 

--- a/backend/main/src/app.py
+++ b/backend/main/src/app.py
@@ -17,6 +17,7 @@ import uvicorn
 # main db imports
 from backend.main.src.routers import student, admin
 from backend.connect_to_mongodb import connect_to_mongodb, connect_to_auth_db
+from backend.main.db.mixins import PresignedPostUrlInfo
 
 # auth db imports
 from backend.auth.dependencies import (
@@ -24,6 +25,7 @@ from backend.auth.dependencies import (
     create_access_token,
     authenticate_user,
     ACCESS_TOKEN_EXPIRE_MIN,
+    create_presigned_post,
 )
 from backend.auth.db.main import get_user_by_email
 
@@ -79,6 +81,18 @@ async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends(
         expires_delta=access_token_expires,
     )
     return {"access_token": access_token, "token_type": "bearer"}
+
+
+@app.post("/presigned_url_for_url")
+async def generate_student_consent_form_url(
+    info: PresignedPostUrlInfo, token_data: TokenData = Depends(get_current_token_data)
+):
+    response = create_presigned_post(info.object_name, info.fields, info.conditions)
+
+    if response is not None:
+        return response
+
+    return {"details": "Could not generate presigned url"}
 
 
 if __name__ == "__main__":

--- a/backend/main/src/routers/admin.py
+++ b/backend/main/src/routers/admin.py
@@ -25,13 +25,12 @@ from backend.main.db.docs.meeting_doc import (
     MeetingDocument,
 )
 from backend.main.db.password_generator import generate_random_password
-from backend.main.db.mixins import PydanticObjectId, PresignedPostUrlInfo
+from backend.main.db.mixins import PydanticObjectId
 
 # auth db imports
 from backend.auth.dependencies import (
     TokenData,
     get_admin_token_data,
-    create_presigned_post,
     create_presigned_url,
 )
 
@@ -104,7 +103,6 @@ async def get_student_consent_form_url(
 
     response = create_presigned_url(object_name)
     if response is not None:
-        print(response)
         return response
 
     return {"details": "Could not generate presigned url"}
@@ -162,19 +160,6 @@ async def create_meeting(
     doc = MeetingDoc(meeting)
     doc.save()
     return doc.admin_dict()
-
-
-@router.post("/create_meeting_material_url")
-async def generate_admin_material_url(
-    info: PresignedPostUrlInfo, token_data: TokenData = Depends(get_admin_token_data)
-):
-    response = create_presigned_post(info.object_name, info.fields, info.conditions)
-
-    if response is not None:
-        print(response)
-        return response
-
-    return {"details": "Could not generate presigned url"}
 
 
 # DELETE routes

--- a/backend/main/src/routers/admin.py
+++ b/backend/main/src/routers/admin.py
@@ -18,17 +18,21 @@ from backend.main.db.models.meeting_model import (
     MeetingModel,
     UpdateMeeting,
     StudentMeetingAttendance,
+    MeetingIdModel,
 )
 from backend.main.db.docs.meeting_doc import (
     document as MeetingDoc,
     MeetingDocument,
 )
 from backend.main.db.password_generator import generate_random_password
+from backend.main.db.mixins import PydanticObjectId, PresignedPostUrlInfo
 
 # auth db imports
 from backend.auth.dependencies import (
     TokenData,
     get_admin_token_data,
+    create_presigned_post,
+    create_presigned_url,
 )
 
 router = APIRouter()
@@ -79,6 +83,59 @@ def get_student_profile(
     return profile.dict()
 
 
+@router.get("/get_student_consent_form_url")
+async def get_student_consent_form_url(
+    student_id: PydanticObjectId, token_data: TokenData = Depends(get_admin_token_data)
+):
+    st_query = StudentDocument.objects(id=student_id)
+    if len(st_query) == 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Could not find student with id {student_id}",
+        )
+
+    student = st_query[0]
+    object_name = student.consent_form_object_name
+    if object_name is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Student has not uploaded consent form yet",
+        )
+
+    response = create_presigned_url(object_name)
+    if response is not None:
+        print(response)
+        return response
+
+    return {"details": "Could not generate presigned url"}
+
+
+@router.get("/get_meeting_material_url")
+async def get_meeting_material_url(
+    meeting_uuid: UUID4, token_data: TokenData = Depends(get_admin_token_data)
+):
+    meeting_query = MeetingDocument.objects(uuid=meeting_uuid)
+    if len(meeting_query) == 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Could not find meeting with uuid {meeting_uuid}",
+        )
+
+    meeting = meeting_query[0]
+    object_name = meeting.materials_object_name
+    if object_name is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Meeting does not have a materials_object_name",
+        )
+
+    response = create_presigned_url(object_name)
+    if response is not None:
+        return response
+
+    return {"details": "Could not generate presigned url"}
+
+
 # POST routes
 @router.post("/get_meetings")
 async def get_meetings_by_filter(
@@ -107,11 +164,24 @@ async def create_meeting(
     return doc.admin_dict()
 
 
+@router.post("/create_meeting_material_url")
+async def generate_admin_material_url(
+    info: PresignedPostUrlInfo, token_data: TokenData = Depends(get_admin_token_data)
+):
+    response = create_presigned_post(info.object_name, info.fields, info.conditions)
+
+    if response is not None:
+        print(response)
+        return response
+
+    return {"details": "Could not generate presigned url"}
+
+
 # DELETE routes
 @router.delete("/delete_meeting")
-async def delete_meeting(update_meeting_model: UpdateMeeting):
+async def delete_meeting(meeting: MeetingIdModel):
     try:
-        meeting_doc = MeetingDocument.objects(uuid=update_meeting_model.meeting_id)[0]
+        meeting_doc = MeetingDocument.objects(uuid=meeting.meeting_id)[0]
     except Exception:
         return "Could not find the meeting"
     meeting_doc.delete()
@@ -169,6 +239,7 @@ async def update_meeting(
     meeting_doc.miro_link = update_meeting_model.miro_link
     meeting_doc.coordinator_notes = update_meeting_model.coordinator_notes
     meeting_doc.student_notes = update_meeting_model.student_notes
-    meeting_doc.materials_link = update_meeting_model.materials_link
+    meeting_doc.materials_uploaded = update_meeting_model.materials_uploaded
+    meeting_doc.materials_object_name = update_meeting_model.materials_object_name
     meeting_doc.save()
     return meeting_doc.admin_dict()

--- a/backend/main/src/routers/student.py
+++ b/backend/main/src/routers/student.py
@@ -1,4 +1,5 @@
 from fastapi import Depends, APIRouter, HTTPException, status
+from pydantic import UUID4
 
 # main db imports
 from backend.main.db.models.student_profile_model import (
@@ -26,13 +27,15 @@ from backend.main.db.models.meeting_model import (
 from backend.main.db.docs.meeting_doc import (
     MeetingDocument,
 )
-from backend.main.db.mixins import PydanticObjectId, SessionLevel
+from backend.main.db.mixins import PydanticObjectId, SessionLevel, PresignedPostUrlInfo
 
 
 # auth db imports
 from backend.auth.dependencies import (
     TokenData,
     get_student_token_data,
+    create_presigned_url,
+    create_presigned_post,
 )
 
 router = APIRouter()
@@ -114,6 +117,7 @@ def update_student_document(student_doc: StudentDocument, updates: StudentUpdate
     student_doc.last_name = updates.last_name
     student_doc.grade = updates.grade
     student_doc.age = updates.age
+    student_doc.consent_form_object_name = updates.consent_form_object_name
     student_doc.save()
 
 
@@ -128,6 +132,67 @@ def get_current_user_profile(token_data: TokenData = Depends(get_student_token_d
 def get_student_names(token_data: TokenData = Depends(get_student_token_data)):
     current_user = get_current_user_doc(token_data)
     return current_user["students"]
+
+
+@router.get("/get_consent_form_url")
+async def get_student_consent_form_url(
+    student_id: PydanticObjectId,
+    token_data: TokenData = Depends(get_student_token_data),
+):
+    st_query = StudentDocument.objects(id=student_id)
+    if len(st_query) == 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Could not find student with id {student_id}",
+        )
+
+    student = st_query[0]
+    if student.profile_uuid != token_data.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Student id is associated with a different account",
+        )
+
+    object_name = student.consent_form_object_name
+    if object_name is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Student has not uploaded consent form yet",
+        )
+
+    response = create_presigned_url(object_name)
+
+    if response is not None:
+        print(response)
+        return response
+
+    return {"details": "Could not generate presigned url"}
+
+
+@router.get("/get_meeting_material_url")
+async def get_meeting_material_url(
+    meeting_uuid: UUID4, token_data: TokenData = Depends(get_student_token_data)
+):
+    meeting_query = MeetingDocument.objects(uuid=meeting_uuid)
+    if len(meeting_query) == 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Could not find meeting with uuid {meeting_uuid}",
+        )
+
+    meeting = meeting_query[0]
+    object_name = meeting.materials_object_name
+    if object_name is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Meeting does not have a materials_object_name",
+        )
+
+    response = create_presigned_url(object_name)
+    if response is not None:
+        return response
+
+    return {"details": "Could not generate presigned url"}
 
 
 # POST routes
@@ -258,6 +323,19 @@ async def update_student(
     return {
         "details": f"Student with id {registration.student_id} added to meeting list"
     }
+
+
+@router.post("/create_consent_form_url")
+async def generate_student_consent_form_url(
+    info: PresignedPostUrlInfo, token_data: TokenData = Depends(get_student_token_data)
+):
+    response = create_presigned_post(info.object_name, info.fields, info.conditions)
+
+    if response is not None:
+        print(response)
+        return response
+
+    return {"details": "Could not generate presigned url"}
 
 
 # PUT routes

--- a/backend/main/src/routers/student.py
+++ b/backend/main/src/routers/student.py
@@ -27,7 +27,7 @@ from backend.main.db.models.meeting_model import (
 from backend.main.db.docs.meeting_doc import (
     MeetingDocument,
 )
-from backend.main.db.mixins import PydanticObjectId, SessionLevel, PresignedPostUrlInfo
+from backend.main.db.mixins import PydanticObjectId, SessionLevel
 
 
 # auth db imports
@@ -35,7 +35,6 @@ from backend.auth.dependencies import (
     TokenData,
     get_student_token_data,
     create_presigned_url,
-    create_presigned_post,
 )
 
 router = APIRouter()
@@ -163,7 +162,6 @@ async def get_student_consent_form_url(
     response = create_presigned_url(object_name)
 
     if response is not None:
-        print(response)
         return response
 
     return {"details": "Could not generate presigned url"}
@@ -323,19 +321,6 @@ async def update_student(
     return {
         "details": f"Student with id {registration.student_id} added to meeting list"
     }
-
-
-@router.post("/create_consent_form_url")
-async def generate_student_consent_form_url(
-    info: PresignedPostUrlInfo, token_data: TokenData = Depends(get_student_token_data)
-):
-    response = create_presigned_post(info.object_name, info.fields, info.conditions)
-
-    if response is not None:
-        print(response)
-        return response
-
-    return {"details": "Could not generate presigned url"}
 
 
 # PUT routes

--- a/backend/tests/test_admin_endpoint.py
+++ b/backend/tests/test_admin_endpoint.py
@@ -174,8 +174,7 @@ def test_delete_meeting(mock_database):
     pre_save_meetings()
     meeting = MeetingDocument.objects()[0]
     id = meeting.uuid
-    update = UpdateMeeting(**meeting1.dict(), meeting_id=id)
-    response = client.delete("/admin/delete_meeting", json=update.dict())
+    response = client.delete("/admin/delete_meeting", json={"meeting_id": f"{id}"})
     assert response.status_code == 200
     meeting = MeetingDocument.objects(uuid=id)
     assert len(meeting) == 0


### PR DESCRIPTION
- Added functions to make presigned urls for s3
- Added `materials_uploaded` field to MeetingDocument; changed `materials_link` to `materials_object_name`
- Created admin routes:
  - GET `admin/get_meeting_material_url` 
  - GET `admin/get_consent_form_url` 
- Created student routes: 
  - GET `student/get_consent_form_url`
  - GET `student/get_meeting_material_url`
 - Created   - POST `/create_url_for_upload` it returns a URL to make a post request
- Simplified `admin/delete_meeting` route