### PR TITLE
Do not return access token if account is disabled

### DIFF
--- a/backend/auth/main.py
+++ b/backend/auth/main.py
@@ -90,6 +90,8 @@ async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends(
     # OAuth2PasswordRequestForm does not have an email field, only username
     user = await get_user_by_email(form_data.username)
     if user:
+        if user.disabled:
+            raise HTTPException(status_code=400, detail="Account is disabled")
         user = authenticate_user(user, form_data.password)
 
     else:


### PR DESCRIPTION
If the account is disabled, the auth server will no longer return an access token.  It instead returns an error 400 with detail "Account is disabled"